### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/collector
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1392