### PR TITLE
Add playbooks for EC2 deployment

### DIFF
--- a/.github/workflows/collector-image.yaml
+++ b/.github/workflows/collector-image.yaml
@@ -91,3 +91,12 @@ jobs:
 
       - name: Push the newly built image to Quay.io
         run: docker push --all-tags ${REGISTRY}/${COLLECTOR_IMAGE_NAME}
+
+         # run ansible deployment to deploy the new image to the cluster
+      - name: (if on main and upstream) Deploy the newly built image to the cluster
+        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbooks/start-collector.yml
+          key: ${{secrets.COLLECTOR_KEYPAIR}}
+          inventory: playbooks/inventory.ini

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -120,3 +120,12 @@ jobs:
       - name: (if on main and upstream) Push the newly built image to Quay.io
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
         run: docker push --all-tags ${REGISTRY}/${COLLECTOR_IMAGE_NAME}
+
+        # run ansible deployment to deploy the new image to the cluster
+      - name: (if on main and upstream) Deploy the newly built image to the cluster
+        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbooks/start-collector.yml
+          key: ${{secrets.COLLECTOR_KEYPAIR}}
+          inventory: playbooks/inventory.ini

--- a/playbooks/inventory.ini
+++ b/playbooks/inventory.ini
@@ -1,2 +1,2 @@
 [collector]
-ec2 ansible_host=ec2-52-91-127-75.compute-1.amazonaws.com ansible_user=ec2-user ansible_private_key_file=~/.ssh/id_rsa
+ec2 ansible_host=44.195.143.94 ansible_user=ec2-user ansible_private_key_file=~/.ssh/id_rsa_git

--- a/playbooks/inventory.ini
+++ b/playbooks/inventory.ini
@@ -1,0 +1,2 @@
+[collector]
+ec2 ansible_host=ec2-52-91-127-75.compute-1.amazonaws.com ansible_user=ec2-user ansible_private_key_file=~/.ssh/id_rsa

--- a/playbooks/start-collector.yaml
+++ b/playbooks/start-collector.yaml
@@ -83,11 +83,9 @@
           docker rm grafana
         fi
         
-    # temporarily cloning from shir's fork and branch
     - name: Clone the collector repo
       ansible.builtin.git:
-        repo: 'https://github.com/shirmoran/collector.git'
-        version: update-makefile-with-grafana
+        repo: 'https://github.com/test-network-function/collector.git'
         dest: /home/ec2-user/collector
         clone: yes
 

--- a/playbooks/start-collector.yaml
+++ b/playbooks/start-collector.yaml
@@ -6,7 +6,7 @@
   vars:
     # Note: Keeping docker packages separate just for organization
     docker_package_names: [docker-ce, docker-ce-cli, containerd.io, docker-compose-plugin, docker-buildx-plugin]
-    yum_packages: [yum-utils, git, device-mapper-persistent-data, lvm2]
+    yum_packages: [yum-utils, git, device-mapper-persistent-data, lvm2, make]
 
   tasks:
     - name: Add ec2-user to sudoers
@@ -29,17 +29,26 @@
 
     - name: Add docker repository to yum
       command: sudo yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+      when: ansible_distribution=="Red Hat Enterprise Linux"
 
     # https://stackoverflow.com/questions/70358656/rhel8-fedora-yum-dns-causes-cannot-download-repodata-repomd-xml-for-docker-ce
     - name: Fix the docker-ce.repo file
       command: sed -i -e 's/baseurl=https:\/\/download\.docker\.com\/linux\/\(fedora\|rhel\)\/$releasever/baseurl\=https:\/\/download.docker.com\/linux\/centos\/$releasever/g' /etc/yum.repos.d/docker-ce.repo
+      when: ansible_distribution=="Red Hat Enterprise Linux"
 
-    - name: Install Required Docker Packages
+    - name: Install Required Docker Packages for RHEL
       yum:
         name: "{{item}}"
         state: present
       with_items: "{{ docker_package_names }}"
+      when: ansible_distribution=="Red Hat Enterprise Linux"
 
+    - name: Install Required Docker Packages for Amazon Linux
+      yum:
+        name: docker
+        state: present
+      when: ansible_distribution!="Red Hat Enterprise Linux"
+      
     - name: Start Docker Service
       service:
         name: docker
@@ -52,12 +61,6 @@
         groups: docker
         append: yes
         state: present
-
-    - name: Remove Collector clone if it exists
-      shell: |
-        if [ -d "./collector" ]; then 
-          sudo rm -rf ./collector
-        fi
 
     - name: Remove Tnf-secrets clone if it exists
       shell: |
@@ -84,17 +87,19 @@
         fi
         
     - name: Clone the collector repo
+      become: no
       ansible.builtin.git:
         repo: 'https://github.com/test-network-function/collector.git'
         dest: /home/ec2-user/collector
         clone: yes
+        force: true
 
     - name: Start Collector container 
       shell: |
         cd collector
-        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa -o IdentitiesOnly=yes' make run-collector-rds
+        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa_git -o IdentitiesOnly=yes' make run-collector-rds
 
     - name: Start Grafana container 
       shell: |
         cd collector
-        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa -o IdentitiesOnly=yes' make run-grafana
+        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa_git -o IdentitiesOnly=yes' make run-grafana

--- a/playbooks/start-collector.yaml
+++ b/playbooks/start-collector.yaml
@@ -52,14 +52,51 @@
         groups: docker
         append: yes
         state: present
-    
+
+    - name: Remove Collector clone if it exists
+      shell: |
+        if [ -d "./collector" ]; then 
+          sudo rm -rf ./collector
+        fi
+
+    - name: Remove Tnf-secrets clone if it exists
+      shell: |
+        if [ -d "./tnf-secrets" ]; then 
+          sudo rm -rf ./tnf-secrets
+        fi
+
+    - name: Remove Collector docker if they exists
+      shell: |
+        if docker ps | grep tnf-collector; then
+          docker stop tnf-collector
+        fi
+        if docker ps -a | grep tnf-collector; then
+          docker rm tnf-collector
+        fi
+
+    - name: Remove Grafana docker if exists
+      shell: |
+        if docker ps | grep grafana; then
+          docker stop grafana
+        fi
+        if docker ps -a | grep grafana; then
+          docker rm grafana
+        fi
+        
+    # temporarily cloning from shir's fork and branch
     - name: Clone the collector repo
       ansible.builtin.git:
-        repo: 'https://github.com/test-network-function/collector.git'
+        repo: 'https://github.com/shirmoran/collector.git'
+        version: update-makefile-with-grafana
         dest: /home/ec2-user/collector
         clone: yes
 
-    # TODO: The collector is now cloned and Docker is running.
-    #      The next step is to run the collector container.
-    #       1) Run the make commands to start the collector container
-    #       2) Run the make commands to start the grafana container
+    - name: Start Collector container 
+      shell: |
+        cd collector
+        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa -o IdentitiesOnly=yes' make run-collector-rds
+
+    - name: Start Grafana container 
+      shell: |
+        cd collector
+        GIT_SSH_COMMAND='ssh -i /home/ec2-user/.ssh/id_rsa -o IdentitiesOnly=yes' make run-grafana

--- a/playbooks/start-collector.yaml
+++ b/playbooks/start-collector.yaml
@@ -1,0 +1,65 @@
+---
+
+- hosts: all
+  become: yes
+
+  vars:
+    # Note: Keeping docker packages separate just for organization
+    docker_package_names: [docker-ce, docker-ce-cli, containerd.io, docker-compose-plugin, docker-buildx-plugin]
+    yum_packages: [yum-utils, git, device-mapper-persistent-data, lvm2]
+
+  tasks:
+    - name: Add ec2-user to sudoers
+      ansible.builtin.lineinfile:
+        dest: /etc/sudoers
+        line: "ec2-user ALL=(ALL) NOPASSWD: ALL"
+        validate: "visudo -cf %s"
+
+    - name: Install yum packages
+      yum:
+        name: "{{item}}"
+        state: present
+        update_cache: yes
+      with_items: "{{ yum_packages }}"
+    
+    - name: Ensure group "docker" exists
+      ansible.builtin.group:
+        name: docker
+        state: present
+
+    - name: Add docker repository to yum
+      command: sudo yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+
+    # https://stackoverflow.com/questions/70358656/rhel8-fedora-yum-dns-causes-cannot-download-repodata-repomd-xml-for-docker-ce
+    - name: Fix the docker-ce.repo file
+      command: sed -i -e 's/baseurl=https:\/\/download\.docker\.com\/linux\/\(fedora\|rhel\)\/$releasever/baseurl\=https:\/\/download.docker.com\/linux\/centos\/$releasever/g' /etc/yum.repos.d/docker-ce.repo
+
+    - name: Install Required Docker Packages
+      yum:
+        name: "{{item}}"
+        state: present
+      with_items: "{{ docker_package_names }}"
+
+    - name: Start Docker Service
+      service:
+        name: docker
+        state: started
+        enabled: yes
+
+    - name: Add ec2-user to docker group
+      ansible.builtin.user:
+        name: ec2-user
+        groups: docker
+        append: yes
+        state: present
+    
+    - name: Clone the collector repo
+      ansible.builtin.git:
+        repo: 'https://github.com/test-network-function/collector.git'
+        dest: /home/ec2-user/collector
+        clone: yes
+
+    # TODO: The collector is now cloned and Docker is running.
+    #      The next step is to run the collector container.
+    #       1) Run the make commands to start the collector container
+    #       2) Run the make commands to start the grafana container


### PR DESCRIPTION
Using `ansible`, we should be able to quickly and easily deploy our latest image directly to EC2 whenever there is a merged PR or on the daily cron image build to keep everything fresh.

Notable changes: 
- Uses [run-ansible-playbook](https://github.com/marketplace/actions/run-ansible-playbook) github action to run our playbook.
- Adds a `playbooks` directory to house the actual playbook and the inventory file.