### PR TITLE
metion use of secrets keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,6 @@ deploy-collector-for-CI:
 deploy-mysql-for-CI:
 	oc apply -f ${MYSQL_DEPLOYMENT_PATH} -n tnf-collector
 
-# Clones tnf-secret private repo (temporary Shir's fork and branch)
+# Clones tnf-secret private repo
 clone-tnf-secrets:
 	git clone git@github.com:test-network-function/tnf-secrets.git

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Run the application via container:
 Cleanup after:
 - `make stop-collector`
 
+Initialize db:
+- `make run-initial-mysql-scripts`
+
 # Instructions for running send-to-collector.sh
 
 From collector's repo root directory, use the following command:

--- a/scripts/database/create_schema.sql
+++ b/scripts/database/create_schema.sql
@@ -38,6 +38,7 @@ create table if not exists authenticator (
   encoded_password varchar(255) not null
 );
 
+-- CollectorAdminUser's and CollectorAdminPassword's values are in tnf-secrets/collector-secrets.json
 insert into authenticator (partner_name, encoded_password)
 select 'CollectorAdminUser', 'CollectorAdminPassword'
 from dual

--- a/scripts/database/create_user.sql
+++ b/scripts/database/create_user.sql
@@ -1,3 +1,4 @@
+-- MysqlUsername's and MysqlPassword's values are in tnf-secrets/collector-secrets.json
 CREATE USER if not exists 'MysqlUsername'@'%' IDENTIFIED BY 'MysqlPassword';
 GRANT ALL PRIVILEGES ON cnf.claim TO 'MysqlUsername'@'%';
 GRANT ALL PRIVILEGES ON cnf.claim_result TO 'MysqlUsername'@'%';


### PR DESCRIPTION
In order to prevent using mysql scripts with secrets keys instead of values, we should mention the use of secrets from tnf-secrets repo. Since it's a private repo it's not a problem mentioning the use of it.