### PR TITLE
fix params indexing

### DIFF
--- a/api/parser_handler.go
+++ b/api/parser_handler.go
@@ -21,8 +21,8 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 	// Valid parameters for database calls
 	partnerName := strings.ToLower(params[0])
 	decodedPassword := params[1]
-	ocpVersion := params[2]
-	executedBy := strings.ToLower(params[3])
+	executedBy := strings.ToLower(params[2])
+	ocpVersion := params[3]
 
 	// 2. Validate partner's credentials, for non-existent partner create an entry in the database
 	// which he has to use each time even when the claim file error happens


### PR DESCRIPTION
params returned from `validatePostRequest(w,r)` are returned in the order:  partnerName, decodedPassword, executedBy, ocpVersion.
`execytedBy` and `cnfVersion` were saving wrong values, this PR fixes the indexing.