### PR TITLE
modify sanity check to run on prod using latest GET request output

### DIFF
--- a/.github/actions/run-sanity-check/action.yaml
+++ b/.github/actions/run-sanity-check/action.yaml
@@ -12,6 +12,10 @@ runs:
   using: 'composite'
   steps:
     - name: Run sanity check script
-      run: ENDPOINT=http://localhost:8080 COLLECTOR_USERNAME=admin COLLECTOR_PASSWORD=password ./scripts/sanity-check.sh
+      run: |
+        ENDPOINT=44.195.143.94 \
+        COLLECTOR_USERNAME=ciuser \
+        COLLECTOR_PASSWORD=cipassword \
+        ./scripts/sanity-check.sh
       working-directory: ${{ inputs.working_directory }}
       shell: bash

--- a/scripts/sanity-check.sh
+++ b/scripts/sanity-check.sh
@@ -19,6 +19,8 @@ fi
 
 # Get results from collector
 results=$(./scripts/get-from-collector.sh "$ENDPOINT" "$COLLECTOR_USERNAME" "$COLLECTOR_PASSWORD")
+start_index=${results%%[*} start_index=$((${#start_index} + 1))
+results="${results:start_index-1}"
 results_test_ids=$(echo "$results" | jq -r '.[-1].ClaimResults[].test_id')
 
 # Get generated policy requiredPassingTests ids


### PR DESCRIPTION
- Collector's GET request return a message saying "server is up" and a json file of the db content. This PR modifies the sanity check to use only the json file content.
- Modifies sanity check to run on prod collector