### PR TITLE
time stamp column in authenticator table

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/test-network-function/collector/util"
 	"golang.org/x/crypto/bcrypt"
@@ -44,7 +45,7 @@ func VerifyCredentialsAndCreateIfNotExists(partnerName, partnerPassword string, 
 			return err
 		}
 		// Create partner entry into the database
-		_, txErr := db.Exec(util.InsertPartnerToAuthSQLCmd, partnerName, encodedPartnerPassword)
+		_, txErr := db.Exec(util.InsertPartnerToAuthSQLCmd, partnerName, encodedPartnerPassword, time.Now())
 		if txErr != nil {
 			return txErr
 		}

--- a/scripts/database/create_schema.sql
+++ b/scripts/database/create_schema.sql
@@ -35,7 +35,8 @@ EXECUTE stmt;
 
 create table if not exists authenticator (
   partner_name varchar(255) not null,
-  encoded_password varchar(255) not null
+  encoded_password varchar(255) not null,
+  creation_time datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 -- CollectorAdminUser's and CollectorAdminPassword's values are in tnf-secrets/collector-secrets.json

--- a/util/constants.go
+++ b/util/constants.go
@@ -55,7 +55,9 @@ const InsertToClaimResSQLCmd = `INSERT INTO claim_result
 							VALUES (?, ?, ?, ?);`
 const ExtractLastClaimID = `SELECT id FROM cnf.claim ORDER BY id DESC LIMIT 1;`
 const ExtractPartnerAndPasswordCmd = `SELECT encoded_password FROM cnf.authenticator WHERE partner_name = ?`
-const InsertPartnerToAuthSQLCmd = `INSERT INTO cnf.authenticator (partner_name, encoded_password) VALUES (?, ?)`
+const InsertPartnerToAuthSQLCmd = `INSERT INTO cnf.authenticator 
+									(partner_name, encoded_password, creation_time)
+									VALUES (?, ?, ?)`
 const ParseLowerBound = 10
 const ParseUpperBound = 20
 const FileStoredIntoClaimTableSuccessfully = `Claim is stored into table successfully.`


### PR DESCRIPTION
Added a "creation_time" column in authenticator to enable cron deletion of ci users.