### PR TITLE
Sanity check modification

### DIFF
--- a/scripts/sanity-check.sh
+++ b/scripts/sanity-check.sh
@@ -21,22 +21,12 @@ fi
 results=$(./scripts/get-from-collector.sh "$ENDPOINT" "$COLLECTOR_USERNAME" "$COLLECTOR_PASSWORD")
 start_index=${results%%[*} start_index=$((${#start_index} + 1))
 results="${results:start_index-1}"
-results_test_ids=$(echo "$results" | jq -r '.[-1].ClaimResults[].test_id')
+results_claim=$(echo "$results" | jq -r '.[-1].Claim')
 
-# Get generated policy requiredPassingTests ids
-GENERATED_POLICY_RAW_URL="https://raw.githubusercontent.com/test-network-function/cnf-certification-test/main/generated_policy.json"
-read -d '' -ra required_test_ids <<<"$(curl $GENERATED_POLICY_RAW_URL | jq -r '.grades.requiredPassingTests[].id')"
-
-# Ensure all ids in ids_array are in results from collector
-echo "Iterating over required passing tests ids..."
-for test_id in "${required_test_ids[@]}"; do
-	if [[ "${results_test_ids[*]}" == *"$test_id"* ]]; then
-		echo "test $test_id exists in the collector"
-	else
-		echo "test $test_id does not exist in the collector"
-		echo "Collector's sanity check has failed."
-		exit 1
-	fi
-done
+if [ -z "$results_claim" ]; then
+	echo "User ${COLLECTOR_USERNAME} doesn't have any claims stored."
+	echo "Collector's sanity check has failed!."
+	exit 1
+fi
 
 echo "Collector's sanity check has passed."


### PR DESCRIPTION
Changes sanity check from iterating over test cases checking they exists in claim results, to only check if a claim under the given partner exists. Since this check is mostly for CI testing, and every run has its unique partner name, this approach should be sufficient to verify collector is working properly. 