### PR TITLE
Typos ignores config file

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -88,6 +88,9 @@ jobs:
 
       - name: Typos
         uses: crate-ci/typos@master
+        with:
+          files: ./depends-on.json
+          isolated: true
         if: runner.os == 'Linux'
 
       - name: Yamllint


### PR DESCRIPTION
The change resolves false positive errors in PRs [1](https://github.com/test-network-function/collector/pull/198) and [2](https://github.com/test-network-function/collector/pull/203).