### PR TITLE
Update GolangCI-lint to v1.59.1

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.59
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,6 @@ linters-settings:
   funlen:
     lines: 50
     statements: 25
-  gci:
-    local-prefixes: github.com/golangci/golangci-lint
   goconst:
     min-len: 4
     min-occurrences: 2
@@ -20,15 +18,12 @@ linters-settings:
       - whyNoLint
   gocyclo:
     min-complexity: 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
   mnd:
     settings:
       mnd:
         # do not include the "operation" and "assign"
         checks: argument,case,condition,return
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -121,6 +116,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.58.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.59.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GIT_COMMIT=$(shell scripts/create-version-files.sh)
 GIT_RELEASE=$(shell scripts/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell scripts/get-git-previous-release.sh)
 BASH_SCRIPTS=$(shell find . -name "*.sh" -not -path "./.git/*")
-GOLANGCI_VERSION=v1.58.1
+GOLANGCI_VERSION=v1.59.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/2216