### PR TITLE
Update Go to v1.25.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/collector
 
-go 1.24.4
+go 1.25.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.3


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3211