### PR TITLE
ci: pin golangci-lint to v2.12.1 and fix gosec G120 finding

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.12.1
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/util/http_utils.go
+++ b/util/http_utils.go
@@ -21,7 +21,7 @@ func WriteMsg(w http.ResponseWriter, err string) {
 
 func GetClaimFile(w http.ResponseWriter, r *http.Request) multipart.File {
 	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-	err := r.ParseMultipartForm(ParseLowerBound << ParseUpperBound)
+	err := r.ParseMultipartForm(ParseLowerBound << ParseUpperBound) //nolint:gosec // body is already bounded by MaxBytesReader above
 	if err != nil {
 		WriteMsg(w, err.Error())
 		logrus.Errorf(RequestContentTypeErr, err)


### PR DESCRIPTION
## Summary
- Pins golangci-lint to v2.12.1 to prevent CI breakage from future releases
- Suppresses gosec G120 false positive on `ParseMultipartForm` — the request body is already bounded by `http.MaxBytesReader` on the preceding line

## Test plan
- [ ] CI lint step passes with pinned version