### PR TITLE
ci: pin ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/deploy-ec2.yaml
+++ b/.github/workflows/deploy-ec2.yaml
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
 
   start-on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check-collector-endpoint
     if: needs.check-collector-endpoint.outputs.endpoint_status == false
 


### PR DESCRIPTION
## Summary
- Pin `ubuntu-latest` to `ubuntu-24.04` in all GitHub Actions workflows

Prevents unexpected behavior changes when GitHub updates the `ubuntu-latest` label.
Tracked by [CNFCERT-1419](https://redhat.atlassian.net/browse/CNFCERT-1419).