### PR TITLE
chore: upgrade to Go 1.26.3 with toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/redhat-best-practices-for-k8s/collector
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Summary

Update `toolchain go1.26.2` to `toolchain go1.26.3` in go.mod for improved compatibility and security.

## Security Fixes

[Go 1.26.3 announcement](https://groups.google.com/g/golang-announce/c/qcCIEXso47M) — 11 CVEs fixed:

| CVE | Package | Issue |
|-----|---------|-------|
| CVE-2026-33814 | net/http | HTTP/2 transport infinite loop via SETTINGS_MAX_FRAME_SIZE of 0 |
| CVE-2026-42501 | cmd/go | Checksum database validation bypass via malicious module proxy |
| CVE-2026-39825 | net/http/httputil | ReverseProxy forwards queries exceeding parameter limit |
| CVE-2026-39836 | net | Dial/LookupPort panic on Windows with NUL byte input |
| CVE-2026-42499 | net/mail | Quadratic DoS in consumePhrase parsing RFC 5322 addresses |
| CVE-2026-39820 | net/mail | Quadratic DoS in consumeComment parsing |
| CVE-2026-39819 | cmd/go | "go bug" symlink following in predictable temp filenames |
| CVE-2026-39817 | cmd/go | "go tool pack" arbitrary file write via path traversal |
| CVE-2026-39826 | html/template | XSS via empty/whitespace type attribute on script tags |
| CVE-2026-33811 | net | Double-free crash in LookupCNAME with long CNAME and cgo resolver |
| CVE-2026-39823 | html/template | Meta content URL escaping bypass causes XSS |

## Related PRs

- redhat-best-practices-for-k8s/certsuite#3682
- redhat-best-practices-for-k8s/certsuite-claim#167
- redhat-best-practices-for-k8s/certsuite-operator#313
- redhat-best-practices-for-k8s/certsuite-overview#146
- redhat-best-practices-for-k8s/certsuite-qe#1479
- redhat-best-practices-for-k8s/checks#41
- redhat-best-practices-for-k8s/cr-scale-operator#11
- redhat-best-practices-for-k8s/kpi-collection-tool#126
- redhat-best-practices-for-k8s/oct#451
- redhat-best-practices-for-k8s/perfdive#63
- redhat-best-practices-for-k8s/privileged-daemonset#360
