### PR TITLE
fix: guard against nil claimFile in ParserHandler

### DIFF
--- a/api/parser_handler.go
+++ b/api/parser_handler.go
@@ -38,6 +38,9 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 
 	// 3. Store file to S3
 	claimFile := util.GetClaimFile(w, r)
+	if claimFile == nil {
+		return
+	}
 	s3BucketName, region, accessKey, secretAccessKey := util.GetS3ConnectEnvVars()
 	awsS3Client := configS3(region, accessKey, secretAccessKey)
 	s3FileKey, err := uploadFileToS3(awsS3Client, claimFile, executedBy, partnerName, s3BucketName)


### PR DESCRIPTION
## Summary

- Add nil check after `GetClaimFile` in `ParserHandler` before passing the result to `uploadFileToS3`
- `GetClaimFile` returns nil on error after writing the error response via `WriteMsg`, but the handler previously passed the nil value directly to `uploadFileToS3`, causing a nil-pointer panic

## Test plan

- [ ] `go build ./...` passes
- [ ] `make lint` passes