### PR TITLE
fix: use bcrypt.DefaultCost instead of MinCost for password hashing

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -39,7 +39,7 @@ func VerifyCredentialsAndCreateIfNotExists(partnerName, partnerPassword string, 
 	// If partner name is not recorded, add partner with encoded password
 	if searchPartnerErr == sql.ErrNoRows {
 		// Encode the given password to make a new entry
-		encodedPartnerPassword, err := bcrypt.GenerateFromPassword([]byte(partnerPassword), bcrypt.MinCost)
+		encodedPartnerPassword, err := bcrypt.GenerateFromPassword([]byte(partnerPassword), bcrypt.DefaultCost)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Replace `bcrypt.MinCost` (cost=4) with `bcrypt.DefaultCost` (cost=10) in `VerifyCredentialsAndCreateIfNotExists`
- MinCost is trivially brute-forceable; DefaultCost is the standard for production password hashing

## Test plan

- [ ] `go build ./...` passes
- [ ] `make lint` passes