### PR TITLE
fix: replace hardcoded DB credentials with Secret reference

### DIFF
--- a/k8s/deployment/app.yml
+++ b/k8s/deployment/app.yml
@@ -31,9 +31,15 @@ spec:
             - name: DB_PORT
               value: "3306"
             - name: DB_USER
-              value: "collectoruser"
+              valueFrom:
+                secretKeyRef:
+                  name: collector-db-credentials
+                  key: username
             - name: DB_PASSWORD
-              value: "password"
+              valueFrom:
+                secretKeyRef:
+                  name: collector-db-credentials
+                  key: password
           ports:
             - containerPort: 8080
           securityContext:


### PR DESCRIPTION
## Summary

- Replace hardcoded DB_USER and DB_PASSWORD values in k8s/deployment/app.yml with secretKeyRef pointing to a collector-db-credentials Secret
- Credentials were visible as plaintext in the public repo

## Test plan

- [ ] YAML is valid (yamllint passes)
- [ ] Deployment references correct Secret name and keys