### PR TITLE
fix: set proper HTTP status codes on error responses

### DIFF
--- a/api/parser_handler.go
+++ b/api/parser_handler.go
@@ -16,7 +16,7 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 	// 1. Validate the request (includes validation of the claim file format)
 	claimResults, params, err := validatePostRequest(w, r)
 	if err != nil {
-		util.WriteMsg(w, err.Error())
+		util.WriteMsg(w, http.StatusBadRequest, err.Error())
 		logrus.Errorf(util.PostRequestIsNotValidErr, err)
 		return
 	}
@@ -31,7 +31,7 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 	// which he has to use each time even when the claim file error happens
 	err = VerifyCredentialsAndCreateIfNotExists(partnerName, decodedPassword, db)
 	if err != nil {
-		util.WriteMsg(w, err.Error())
+		util.WriteMsg(w, http.StatusUnauthorized, err.Error())
 		logrus.Errorf(util.AuthError, err)
 		return
 	}
@@ -46,7 +46,7 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 	awsS3Client := configS3(ctx, region, accessKey, secretAccessKey)
 	s3FileKey, err := uploadFileToS3(ctx, awsS3Client, claimFile, executedBy, partnerName, s3BucketName)
 	if err != nil {
-		util.WriteMsg(w, err.Error())
+		util.WriteMsg(w, http.StatusInternalServerError, err.Error())
 		logrus.Errorf(util.FailedToUploadFileToS3Err, err)
 		return
 	}
@@ -55,11 +55,11 @@ func ParserHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storage
 	err = util.StoreClaimFileInDatabase(db, claimResults, partnerName, executedBy, ocpVersion, s3FileKey)
 	if err != nil {
 		deleteFileFromS3(ctx, awsS3Client, s3FileKey, s3BucketName)
-		util.WriteMsg(w, err.Error())
+		util.WriteMsg(w, http.StatusInternalServerError, err.Error())
 		logrus.Errorf(util.ClaimFileError, err)
 		return
 	}
 
 	// Successfully uploaded file
-	util.WriteMsg(w, util.SuccessUploadingFileMSG)
+	util.WriteMsg(w, http.StatusOK, util.SuccessUploadingFileMSG)
 }

--- a/api/result_handler.go
+++ b/api/result_handler.go
@@ -17,7 +17,7 @@ func ResultsHandler(w http.ResponseWriter, r *http.Request, mysqlStorage *storag
 	partnerName, err := validateGetRequest(r, db)
 
 	if err != nil {
-		util.WriteMsg(w, err.Error())
+		util.WriteMsg(w, http.StatusUnauthorized, err.Error())
 		logrus.Errorf(util.AuthError, err)
 		return
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -34,12 +34,10 @@ func (s *Server) Start() error {
 
 func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 	if err := s.database.MySQL.Ping(); err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		util.WriteMsg(w, "database unreachable")
+		util.WriteMsg(w, http.StatusServiceUnavailable, "database unreachable")
 		return
 	}
-	w.WriteHeader(http.StatusOK)
-	util.WriteMsg(w, "ok")
+	util.WriteMsg(w, http.StatusOK, "ok")
 }
 
 func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +49,7 @@ func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		ParserHandler(w, r, s.database)
 	default:
-		util.WriteMsg(w, util.InvalidRequestErr)
+		util.WriteMsg(w, http.StatusMethodNotAllowed, util.InvalidRequestErr)
 		logrus.Errorf(util.InvalidRequestErr)
 	}
 }

--- a/util/http_utils.go
+++ b/util/http_utils.go
@@ -11,10 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Writes Error or Msg using http response writer.
-func WriteMsg(w http.ResponseWriter, err string) {
+func WriteMsg(w http.ResponseWriter, statusCode int, msg string) {
 	w.Header().Set("Content-Type", "text/plain")
-	if _, writeErr := fmt.Fprintln(w, err); writeErr != nil { //nolint:gosec // response is text/plain, not HTML
+	w.WriteHeader(statusCode)
+	if _, writeErr := fmt.Fprintln(w, msg); writeErr != nil { //nolint:gosec // response is text/plain, not HTML
 		logrus.Errorf(WritingResponseErr, writeErr)
 	}
 }
@@ -23,14 +23,14 @@ func GetClaimFile(w http.ResponseWriter, r *http.Request) multipart.File {
 	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
 	err := r.ParseMultipartForm(ParseLowerBound << ParseUpperBound) //nolint:gosec // body is already bounded by MaxBytesReader above
 	if err != nil {
-		WriteMsg(w, err.Error())
+		WriteMsg(w, http.StatusBadRequest, err.Error())
 		logrus.Errorf(RequestContentTypeErr, err)
 		return nil
 	}
 
 	claimFile, _, err := r.FormFile(ClaimFileInputName)
 	if err != nil {
-		WriteMsg(w, err.Error())
+		WriteMsg(w, http.StatusBadRequest, err.Error())
 		logrus.Errorf(FormFileErr, err)
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Add statusCode parameter to WriteMsg so callers can set the appropriate HTTP status
- Previously all responses (including errors) returned HTTP 200
- Now returns: 400 for validation errors, 401 for auth failures, 405 for invalid methods, 500 for server-side failures

## Files changed

- util/http_utils.go — WriteMsg signature updated, internal callers updated
- api/parser_handler.go — 5 call sites updated with appropriate status codes
- api/result_handler.go — 1 call site updated (401 for auth errors)
- api/server.go — 1 call site updated (405 for invalid method)

## Test plan

- [ ] go build ./... passes
- [ ] make lint passes