### PR TITLE
ci: remove depends-on-action from workflows

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install checkmake
         run: go install github.com/checkmake/checkmake/cmd/checkmake@latest
 


### PR DESCRIPTION
## Summary

Remove the `depends-on/depends-on-action` step from `.github/workflows/pre-main.yaml`.

## Why

The `depends-on/depends-on-action` uses Node.js 20, which GitHub [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and began forcing to Node.js 24 on June 16, 2026. This causes the action to fail with HTTP 500 errors, breaking CI on every PR.

The action has an [open issue (#69)](https://github.com/depends-on/depends-on-action/issues/69) to upgrade, but no fix has been released.

Jira: [CNFCERT-1424](https://redhat.atlassian.net/browse/CNFCERT-1424)

## Related PRs

- [certsuite#3731](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3731)
- [certsuite-operator#317](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/317)
- [certsuite-operator-plugin#12](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/12)
- [certsuite-qe#1498](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1498)