### PR TITLE
docs: fix Go version, add missing targets and directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,16 +29,35 @@ make install-mac-brew-tools  # Install linting tools on macOS via Homebrew
 
 ### Container Images
 ```bash
-make build-image-collector   # Build Docker image
-make push-image-collector    # Push image to registry
-make run-collector           # Run collector locally in Docker (requires tnf-secrets)
-make stop-running-collector-container  # Stop running container
+make build-image-collector              # Build Docker image with latest tag
+make build-image-collector-legacy       # Build Docker image under legacy image name (testnetworkfunction/collector)
+make build-image-collector-by-version   # Build Docker image with both latest and version tags
+make push-image-collector               # Push image with latest tag to registry
+make push-image-collector-by-version    # Push image with both latest and version tags
+make pull-image-collector               # Pull collector image from quay.io
+make run-collector                      # Run collector locally in Docker (requires tnf-secrets)
+make run-collector-rds                  # Run collector against AWS RDS database (requires tnf-secrets)
+make run-collector-rds-headless         # Run collector against RDS in headless mode (requires tnf-secrets)
+make stop-running-collector-container   # Stop running collector container
 ```
 
 ### Database Setup
 ```bash
 make run-initial-mysql-scripts      # Initialize local MySQL (requires tnf-secrets)
 make run-initial-mysql-scripts-rds  # Initialize AWS RDS MySQL
+```
+
+### Kubernetes / CI Deployment
+```bash
+make deploy-collector-for-CI   # Deploy collector to OpenShift namespace for CI testing
+make deploy-mysql-for-CI       # Deploy MySQL to OpenShift namespace for CI testing
+```
+
+### Grafana
+```bash
+make run-grafana                       # Start local Grafana with collector + certsuite-overview dashboards (requires tnf-secrets)
+make stop-running-grafana-container    # Stop running Grafana container
+make clone-certsuite-overview          # Clone the certsuite-overview repo (used by run-grafana)
 ```
 
 ### Client Scripts
@@ -89,6 +108,19 @@ util/
   constants.go    # SQL queries, error messages, form field names
   http_utils.go   # Environment variable handling, HTTP utilities
   db_utils.go     # Database transaction management
+k8s/
+  deployment/
+    app.yml       # Kubernetes Deployment manifest for the collector
+    database.yaml # Kubernetes Deployment manifest for MySQL
+playbooks/
+  start-collector.yaml  # Ansible playbook for starting the collector
+  inventory.ini         # Ansible inventory file
+grafana/
+  datasource/
+    datasource-config.yaml  # Grafana datasource configuration template
+  dashboard/
+    dashboard-config.yaml       # Grafana dashboard provisioning config
+    collector-dashboard.json    # Collector Grafana dashboard definition
 ```
 
 ### Database Schema
@@ -120,4 +152,4 @@ Production secrets are stored in a separate private repository (`tnf-secrets`). 
 
 ## Go Version
 
-This project uses Go 1.25.5.
+This project uses Go 1.26.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and has to be enabled manually by the user running the CNF Certification Suites.
 If you haven't already, clone Collector's repository:
 
 ```sh
-git pull https://github.com/redhat-best-practices-for-k8s/collector.git
+git clone https://github.com/redhat-best-practices-for-k8s/collector.git
 ```
 
 From collector's repo root directory, use the following command:
@@ -109,7 +109,7 @@ can have access to their saved data.\
 If you haven't already, clone Collector's repository:
 
 ```sh
-git pull https://github.com/redhat-best-practices-for-k8s/collector.git
+git clone https://github.com/redhat-best-practices-for-k8s/collector.git
 ```
 
 From collector's repo root directory, use the following command:
@@ -159,13 +159,14 @@ See an output example:
 
 #### Option 2 - For Admin only
 
-Access the data through
-[Collector's grafana dashboard](http://44.195.143.94:3000/d/e5530a23-24b9-4e7f-ab28-8e778d99f429/collector-s-dashboard?orgId=1).
+Access the data through the Collector's Grafana dashboard.
+To run Grafana locally, see the `make run-grafana` target.
 
 ## Run Collector Locally
 
 ### Prerequisites
 
+* Go 1.26 or later
 * Docker or Podman
 * MySQL
 
@@ -176,7 +177,7 @@ Use the following commands to build and run Collector's container and database l
 * **Clone Collector's repository:**
 
     ```sh
-    git pull https://github.com/redhat-best-practices-for-k8s/collector.git
+    git clone https://github.com/redhat-best-practices-for-k8s/collector.git
     ```
 
 * **(Optional) Build and Push your Collector image:**


### PR DESCRIPTION
## Summary

- Fix Go version from 1.25.5 to 1.26 in AGENTS.md (CLAUDE.md)
- Add ~15 undocumented Makefile targets: run-collector-rds, run-collector-rds-headless, build-image-collector-legacy, build-image-collector-by-version, push-image-collector-by-version, deploy-collector-for-CI, deploy-mysql-for-CI, run-grafana, stop-running-grafana-container, pull-image-collector, clone-certsuite-overview
- Add k8s/, playbooks/, and grafana/ directories to the package structure
- Fix `git pull` to `git clone` in README.md (3 occurrences)
- Remove stale bare-IP Grafana link, point to `make run-grafana` instead
- Add Go 1.26 version requirement to README prerequisites